### PR TITLE
Use sudo instead

### DIFF
--- a/src/haskell/install.sh
+++ b/src/haskell/install.sh
@@ -44,7 +44,15 @@ if [[ "${INSTALL_STACK_GHCUP_HOOK}" = "false" ]]; then
     export BOOTSTRAP_HASKELL_INSTALL_NO_STACK_HOOK="true"
 fi
 
+# The installation script is designed to be run by the non-root user
+# The files need to be in the remote user's ~/ home directory
+ROOT_HOME="${HOME}"
+export HOME="${_REMOTE_USER_HOME}"
+
 curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | $SHELL
+
+export HOME="${ROOT_HOME}"
+chown -R "${_REMOTE_USER}:${_REMOTE_USER}" "${_REMOTE_USER_HOME}"
 
 # without restarting the shell, ghci location would not be resolved from the updated PATH
 exec $SHELL

--- a/src/haskell/install.sh
+++ b/src/haskell/install.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
 GHC_VERSION="${GHCVERSION:-"latest"}"
-CABAL_VERSION="${CABALVERSION:-"latest"}" 
-INCLUDE_STACK="${INSTALLSTACK:-"true"}" 
-ADJUST_BASHRC="${ADJUSTBASH:-"true"}" 
+CABAL_VERSION="${CABALVERSION:-"latest"}"
+INCLUDE_STACK="${INSTALLSTACK:-"true"}"
+ADJUST_BASHRC="${ADJUSTBASH:-"true"}"
 
 INSTALL_STACK_GHCUP_HOOK="${INSTALLSTACKGHCUPHOOK:-"true"}"
 
-# Clean up 
+# Clean up
 rm -rf /var/lib/apt/lists/*
 
 if [ "$(id -u)" -ne 0 ]; then
@@ -17,7 +17,7 @@ fi
 
 # Checks if packages are installed and installs them if not
 check_packages() {
-    if ! dpkg -s "$@" > /dev/null 2>&1; then
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
         if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
             echo "Running apt-get update..."
             apt-get update -y
@@ -30,27 +30,26 @@ check_packages curl build-essential libffi-dev libffi8ubuntu1 libgmp-dev libgmp1
 
 export BOOTSTRAP_HASKELL_NONINTERACTIVE=1
 export GHCUP_USE_XDG_DIRS=1
-export BOOTSTRAP_HASKELL_GHC_VERSION="${GHC_VERSION}" 
+export BOOTSTRAP_HASKELL_GHC_VERSION="${GHC_VERSION}"
 export BOOTSTRAP_HASKELL_CABAL_VERSION="${CABAL_VERSION}"
 export BOOTSTRAP_HASKELL_DOWNLOADER="curl"
 
-if [[ "${INCLUDE_STACK}" = "false" ]] ; then
+if [[ "${INCLUDE_STACK}" = "false" ]]; then
     export BOOTSTRAP_HASKELL_INSTALL_NO_STACK="true"
 fi
-if [[ "${ADJUST_BASH}" = "true" ]] ; then
+if [[ "${ADJUST_BASH}" = "true" ]]; then
     export BOOTSTRAP_HASKELL_ADJUST_BASHRC="true"
 fi
-if [[ "${INSTALL_STACK_GHCUP_HOOK}" = "false" ]] ; then
+if [[ "${INSTALL_STACK_GHCUP_HOOK}" = "false" ]]; then
     export BOOTSTRAP_HASKELL_INSTALL_NO_STACK_HOOK="true"
 fi
 
 curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | $SHELL
 
-
 # without restarting the shell, ghci location would not be resolved from the updated PATH
 exec $SHELL
 
-# Clean up 
+# Clean up
 rm -rf /var/lib/apt/lists/*
 
 echo "Done!"

--- a/src/haskell/install.sh
+++ b/src/haskell/install.sh
@@ -46,13 +46,15 @@ fi
 
 # The installation script is designed to be run by the non-root user
 # The files need to be in the remote user's ~/ home directory
-ROOT_HOME="${HOME}"
-export HOME="${_REMOTE_USER_HOME}"
-
-curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | $SHELL
-
-export HOME="${ROOT_HOME}"
-chown -R "${_REMOTE_USER}:${_REMOTE_USER}" "${_REMOTE_USER_HOME}"
+# So, how do we switch users? We use 'sudo -iu <username>' to get a
+# login shell of another user! We use $_REMOTE_USER as defined in
+# a spec proposal (but still implemented in Codespaces): https://github.com/devcontainers/spec/blob/main/proposals/features-user-env-variables.md
+# Here's some more examples using it: https://github.com/search?q=org%3Adevcontainers+_REMOTE_USER&type=code
+# We also use /bin/sh as defined in the script hash-bang line instead of $SHELL.
+sudo -iu "$_REMOTE_USER" <<EOF
+  # https://www.haskell.org/ghcup/
+  curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+EOF
 
 # without restarting the shell, ghci location would not be resolved from the updated PATH
 exec $SHELL


### PR DESCRIPTION
I was able to use `sudo` which seems more "proper" than mutating the `$HOME` variable.

```sh
sudo -iu "$_REMOTE_USER" <<EOF
  # https://www.haskell.org/ghcup/
  curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
EOF
```

Relevant StackOverflow questions:
1. [How do I use su to execute the rest of the bash script as that user?](https://stackoverflow.com/questions/1988249/how-do-i-use-su-to-execute-the-rest-of-the-bash-script-as-that-user) -- where I got the `sudo -iu <username>` from
2. [sudo as another user with their environment](https://unix.stackexchange.com/questions/176997/sudo-as-another-user-with-their-environment) -- verify that it sets the `$HOME` when you pass `-i`

Here's [a working package/image/thing](https://github.com/jcbhmr/devcontainers-contrib-features/pkgs/container/devcontainers-contrib-features%2Fhaskell) that I tested and it worked:

![image](https://user-images.githubusercontent.com/61068799/203697289-822f06d2-b9d1-4553-8bf2-caf1c8b470fa.png)

Here's more info about sudo: https://cheat.sh/sudo