### PR TITLE
Use sudo -iu instead of mutating $HOME

### DIFF
--- a/src/haskell/install.sh
+++ b/src/haskell/install.sh
@@ -46,13 +46,15 @@ fi
 
 # The installation script is designed to be run by the non-root user
 # The files need to be in the remote user's ~/ home directory
-ROOT_HOME="${HOME}"
-export HOME="${_REMOTE_USER_HOME}"
-
-curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | $SHELL
-
-export HOME="${ROOT_HOME}"
-chown -R "${_REMOTE_USER}:${_REMOTE_USER}" "${_REMOTE_USER_HOME}"
+# So, how do we switch users? We use 'sudo -iu <username>' to get a
+# login shell of another user! We use $_REMOTE_USER as defined in
+# a spec proposal (but still implemented in Codespaces): https://github.com/devcontainers/spec/blob/main/proposals/features-user-env-variables.md
+# Here's some more examples using it: https://github.com/search?q=org%3Adevcontainers+_REMOTE_USER&type=code
+# We also use /bin/sh as defined in the script hash-bang line instead of $SHELL.
+sudo -iu "$_REMOTE_USER" <<EOF
+  # https://www.haskell.org/ghcup/
+  curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+EOF
 
 # without restarting the shell, ghci location would not be resolved from the updated PATH
 exec $SHELL


### PR DESCRIPTION
_Sorry about that bogus PR #1 which was against `main`. My bad!_

I was able to use `sudo` which seems more "proper" than mutating the `$HOME` variable.

```sh
sudo -iu "$_REMOTE_USER" <<EOF
  # https://www.haskell.org/ghcup/
  curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
EOF
```

Relevant StackOverflow questions:
1. [How do I use su to execute the rest of the bash script as that user?](https://stackoverflow.com/questions/1988249/how-do-i-use-su-to-execute-the-rest-of-the-bash-script-as-that-user) -- where I got the `sudo -iu <username>` from
2. [sudo as another user with their environment](https://unix.stackexchange.com/questions/176997/sudo-as-another-user-with-their-environment) -- verify that it sets the `$HOME` when you pass `-i`

Here's [a working package/image/thing](https://github.com/jcbhmr/devcontainers-contrib-features/pkgs/container/devcontainers-contrib-features%2Fhaskell) that I tested and it worked:

![image](https://user-images.githubusercontent.com/61068799/203697289-822f06d2-b9d1-4553-8bf2-caf1c8b470fa.png)

Here's more info about sudo: https://cheat.sh/sudo